### PR TITLE
modify build.xml to accept COOJA_PATH from shell environment

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 
 <project name="TerrainLOS Radio Medium" default="jar" basedir=".">
+  <property environment="env"/>
+  <property name="env.COOJA_PATH" value="${user.home}/contiki/tools/cooja"/>
   <property name="java" location="java"/>
   <property name="build" location="build"/>
   <property name="lib" location="lib"/>
-  <property name="cooja" location="${user.home}/contiki/tools/cooja"/>
+  <property name="cooja" location="${env.COOJA_PATH}"/>
 
   <target name="init">
     <tstamp/>
@@ -34,11 +36,11 @@
       </manifest>
     </jar>
   </target>
-  
+
   <target name="jar_cooja">
     <ant antfile="build.xml" dir="${cooja}" target="jar_cooja" inheritAll="false"/>
   </target>
-  
+
   <target name="test" depends="jar">
     <ant antfile="build.xml" dir="${cooja}" target="run_nogui" inheritAll="false">
       <property name="args" value="${basedir}/tests/terrainlos_simple_well_test.csc"/>


### PR DESCRIPTION
This allows passing a parameter called COOJA_PATH to the `ant jar` command. 

* Old behavior: cooja path is hardcoded as `~/contiki/tools/cooja`
* New behavior: cooja path is set to the `COOJA_PATH` environment variable, but falls back to the default of `~/contiki/tools/cooja` if `COOJA_PATH` is undefined.

See here: https://github.com/TerrainLOS/installer/blob/b77c3ea4faf48fa4f89fc5e25632fd7be72e93ff/install.sh#L171